### PR TITLE
Update national-code.service.ts

### DIFF
--- a/src/services/national-code.service.ts
+++ b/src/services/national-code.service.ts
@@ -16,20 +16,6 @@ export class NationalCodeService {
     if (nationalCode.length !== 10)
       return false;
 
-    switch (nationalCode) {
-      case '0000000000':
-      case '1111111111':
-      case '2222222222':
-      case '3333333333':
-      case '4444444444':
-      case '5555555555':
-      case '6666666666':
-      case '7777777777':
-      case '8888888888':
-      case '9999999999':
-        return false;
-    }
-
     var c = parseInt(nationalCode.charAt(9));
     var n = parseInt(nationalCode.charAt(0)) * 10 + parseInt(nationalCode.charAt(1)) * 9 + parseInt(nationalCode.charAt(2)) * 8 + parseInt(nationalCode.charAt(3)) * 7 + parseInt(nationalCode.charAt(4)) * 6 + parseInt(nationalCode.charAt(5)) * 5 + parseInt(nationalCode.charAt(6)) * 4 + parseInt(nationalCode.charAt(7)) * 3 + parseInt(nationalCode.charAt(8)) * 2;
     var r = n - Math.round(n / 11) * 11;


### PR DESCRIPTION
Persian national codes with all-identical digits are valid. See [here](https://www.fardanews.com/fa/news/127747/%D8%B1%D9%86%D8%AF%D8%AA%D8%B1%DB%8C%D9%86-%D8%B4%D9%85%D8%A7%D8%B1%D9%87-%D9%85%D9%84%DB%8C-%D8%A8%D9%84%D8%A7%DB%8C-%D8%AC%D8%A7%D9%86-%D8%B5%D8%A7%D8%AD%D8%A8%D8%B4-%D8%B4%D8%AF).